### PR TITLE
Remove consultation CTA button from sticky banner

### DIFF
--- a/src/components/CTASticky.jsx
+++ b/src/components/CTASticky.jsx
@@ -15,9 +15,6 @@ const CTASticky = () => {
           Connect with TerraNova advisors for a bespoke consultation or speak with our team right away.
         </p>
         <div className="cta-sticky__actions">
-          <a className="btn" href="#contact">
-            📅 Schedule a Consultation
-          </a>
           <a className="btn btn--ghost" href="tel:+639178801122">
             📞 +63 917 880 1122
           </a>


### PR DESCRIPTION
## Summary
- remove the schedule consultation button from the sticky CTA component
- keep the phone contact link as the sole quick action

## Testing
- `npm run build` *(fails: vite not installed in environment)*
- `npm install` *(fails: npm registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68de1ad9ef10833388b361a1c0dea815