### PR TITLE
Improve mobile header layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -830,6 +830,22 @@ main {
 
   .header__inner {
     padding: 0.75rem 1rem;
+    align-items: center;
+  }
+
+  .header__brand {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .header__brand-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.1;
+  }
+
+  .header__brand-tagline {
+    margin-top: 0.2rem;
   }
 
   .hero {


### PR DESCRIPTION
## Summary
- align the brand block and hamburger menu on a single row for small screens
- stack the Land Stewardship Advisors tagline beneath the TerraNova Realty name on mobile

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68de2020e1a08333b41102e8c487aa23